### PR TITLE
feat: add monorepo server and client skeleton

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -1,0 +1,10 @@
+# Game Monorepo
+
+This monorepo contains a NestJS server and a Vue 3 client for a simple multiplayer strategy prototype.
+
+## Packages
+
+- `server/` – NestJS + TypeORM application exposing REST endpoints and a Socket.IO lobby.
+- `client/` – Vue 3 front‑end using Vite and Pinia.
+
+Refer to the README files inside each package for setup instructions.

--- a/game/client/index.html
+++ b/game/client/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Game</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/game/client/package.json
+++ b/game/client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "game-client",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "pinia": "^2.1.4",
+    "socket.io-client": "^4.7.2",
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.0",
+    "@vitejs/plugin-vue": "^4.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^4.4.0"
+  }
+}

--- a/game/client/src/api/http.ts
+++ b/game/client/src/api/http.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const http = axios.create({
+  baseURL: 'http://localhost:3000',
+});

--- a/game/client/src/app.vue
+++ b/game/client/src/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <router-view />
+</template>
+
+<script setup lang="ts">
+</script>

--- a/game/client/src/components/MapCanvas.vue
+++ b/game/client/src/components/MapCanvas.vue
@@ -1,0 +1,31 @@
+<template>
+  <svg :viewBox="'0 0 800 600'" width="800" height="600">
+    <g>
+      <line v-for="edge in map.edges" :key="edge.from + '-' + edge.to"
+        :x1="nodeById(edge.from).x" :y1="nodeById(edge.from).y"
+        :x2="nodeById(edge.to).x" :y2="nodeById(edge.to).y"
+        stroke="#999" />
+      <g v-for="node in map.nodes" :key="node.id">
+        <circle :cx="node.x" :cy="node.y" r="20" :fill="color(node)" />
+        <text :x="node.x" :y="node.y - 25" font-size="12" text-anchor="middle">{{ node.kind }}</text>
+      </g>
+    </g>
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { MapNode, MatchState, NodeState } from '../types';
+
+const props = defineProps<{ map: MatchState['map']; nodesState: NodeState[] }>();
+
+function nodeById(id: number): MapNode {
+  return props.map.nodes.find(n => n.id === id)!;
+}
+
+function color(node: MapNode) {
+  const state = props.nodesState.find(s => s.nodeId === node.id);
+  if (state?.owner === 'A') return 'blue';
+  if (state?.owner === 'B') return 'red';
+  return 'gray';
+}
+</script>

--- a/game/client/src/main.ts
+++ b/game/client/src/main.ts
@@ -1,0 +1,9 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './app.vue';
+import router from './router';
+
+const app = createApp(App);
+app.use(createPinia());
+app.use(router);
+app.mount('#app');

--- a/game/client/src/pages/Lobby.vue
+++ b/game/client/src/pages/Lobby.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <div>
+      <input v-model="matchId" placeholder="match id" />
+      <button @click="create">Создать матч</button>
+      <button @click="join">Войти</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useSocketStore } from '../store/socket';
+import { useRouter } from 'vue-router';
+
+const matchId = ref('');
+const socket = useSocketStore();
+const router = useRouter();
+
+socket.connect();
+
+async function create() {
+  const res: any = await socket.emitAck('lobby:create', { mapBlueprintId: 1 });
+  if (res.ok) {
+    router.push(`/match/${res.matchId}`);
+  }
+}
+
+async function join() {
+  if (!matchId.value) return;
+  const res: any = await socket.emitAck('lobby:join', { matchId: matchId.value });
+  if (res.ok) {
+    router.push(`/match/${matchId.value}`);
+  }
+}
+</script>

--- a/game/client/src/pages/LoginGuest.vue
+++ b/game/client/src/pages/LoginGuest.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="login">
+    <button @click="login">Войти гостем</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from '../store/auth';
+import { http } from '../api/http';
+import { useRouter } from 'vue-router';
+
+const auth = useAuthStore();
+const router = useRouter();
+
+async function login() {
+  const { data } = await http.post('/auth/guest');
+  auth.setAuth(data.token, data.user);
+  router.push('/lobby');
+}
+</script>

--- a/game/client/src/pages/Match.vue
+++ b/game/client/src/pages/Match.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <MapCanvas v-if="state" :map="state.map" :nodes-state="state.nodesState" />
+    <div v-if="state">
+      <div v-for="p in state.players" :key="p.userId">
+        {{ p.nickname }} ({{ p.team }})
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useSocketStore } from '../store/socket';
+import MapCanvas from '../components/MapCanvas.vue';
+import { MatchState } from '../types';
+
+const route = useRoute();
+const socket = useSocketStore();
+const state = ref<MatchState | null>(null);
+
+onMounted(async () => {
+  if (!socket.socket) socket.connect();
+  const id = route.params.id as string;
+  const res: any = await socket.emitAck('lobby:join', { matchId: id });
+  if (res.ok) state.value = res.state;
+});
+</script>

--- a/game/client/src/router.ts
+++ b/game/client/src/router.ts
@@ -1,0 +1,13 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import LoginGuest from './pages/LoginGuest.vue';
+import Lobby from './pages/Lobby.vue';
+import Match from './pages/Match.vue';
+
+export default createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', component: LoginGuest },
+    { path: '/lobby', component: Lobby },
+    { path: '/match/:id', component: Match }
+  ]
+});

--- a/game/client/src/store/auth.ts
+++ b/game/client/src/store/auth.ts
@@ -1,0 +1,14 @@
+import { defineStore } from 'pinia';
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    token: '' as string,
+    user: null as { id: string; nickname: string } | null
+  }),
+  actions: {
+    setAuth(token: string, user: { id: string; nickname: string }) {
+      this.token = token;
+      this.user = user;
+    }
+  }
+});

--- a/game/client/src/store/socket.ts
+++ b/game/client/src/store/socket.ts
@@ -1,0 +1,19 @@
+import { io, Socket } from 'socket.io-client';
+import { defineStore } from 'pinia';
+import { useAuthStore } from './auth';
+
+export const useSocketStore = defineStore('socket', {
+  state: () => ({ socket: null as Socket | null }),
+  actions: {
+    connect() {
+      const auth = useAuthStore();
+      this.socket = io('http://localhost:3000', { path: '/ws', query: { 'auth.token': auth.token } });
+    },
+    async emitAck(event: string, payload: any) {
+      if (!this.socket) throw new Error('No socket');
+      return await new Promise((resolve) => {
+        this.socket.emit(event, payload, resolve);
+      });
+    }
+  }
+});

--- a/game/client/src/types.ts
+++ b/game/client/src/types.ts
@@ -1,0 +1,13 @@
+export type Team = 'A' | 'B';
+export type NodeKind = 'BASE' | 'RESOURCE' | 'DEFENSE' | 'ARMY' | 'SPECIAL';
+
+export interface MapNode { id: number; kind: NodeKind; x: number; y: number; }
+export interface MapEdge { from: number; to: number; distance: number; }
+export interface MatchPlayer { userId: string; nickname: string; team: Team; }
+export interface NodeState { nodeId: number; owner: Team | null; garrison: number; }
+export interface MatchState {
+  matchId: string;
+  players: MatchPlayer[];
+  map: { blueprintId: number; nodes: MapNode[]; edges: MapEdge[] };
+  nodesState: NodeState[];
+}

--- a/game/client/tsconfig.json
+++ b/game/client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/game/client/vite.config.ts
+++ b/game/client/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173
+  }
+});

--- a/game/pnpm-workspace.yaml
+++ b/game/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'client'
+  - 'server'

--- a/game/server/.env.example
+++ b/game/server/.env.example
@@ -1,0 +1,16 @@
+# SERVER
+PORT=3000
+CORS_ORIGIN=http://localhost:5173
+
+# JWT
+JWT_SECRET=dev_secret_change_me
+JWT_EXPIRES=7d
+
+# DB (OpenServer MySQL)
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_USER=root
+DB_PASS=
+DB_NAME=game
+DB_SSL=false
+DB_TZ=Z

--- a/game/server/data-source.ts
+++ b/game/server/data-source.ts
@@ -1,0 +1,20 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { config } from 'dotenv';
+config({ path: process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env' });
+
+export const AppDataSource = new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME,
+  synchronize: false,
+  logging: false,
+  entities: [__dirname + '/src/**/*.entity{.ts,.js}'],
+  migrations: [__dirname + '/migrations/*{.ts,.js}'],
+  charset: 'utf8mb4',
+  timezone: process.env.DB_TZ ?? 'Z',
+  ssl: process.env.DB_SSL === 'true'
+});

--- a/game/server/migrations/1710000000000-init.ts
+++ b/game/server/migrations/1710000000000-init.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class init1710000000000 implements MigrationInterface {
+  name = 'init1710000000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE \`users\` (
+      \`id\` varchar(36) NOT NULL PRIMARY KEY,
+      \`nickname\` varchar(255) NOT NULL UNIQUE,
+      \`created_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB CHARACTER SET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`matches\` (
+      \`id\` varchar(36) NOT NULL PRIMARY KEY,
+      \`status\` enum('WAITING','RUNNING','FINISHED') NOT NULL DEFAULT 'WAITING',
+      \`created_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB CHARACTER SET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`match_participants\` (
+      \`id\` varchar(36) NOT NULL PRIMARY KEY,
+      \`team\` enum('A','B') NOT NULL,
+      \`joined_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      \`matchId\` varchar(36) NULL,
+      \`userId\` varchar(36) NULL,
+      CONSTRAINT FK_match FOREIGN KEY (\`matchId\`) REFERENCES \`matches\`(\`id\`) ON DELETE CASCADE,
+      CONSTRAINT FK_user FOREIGN KEY (\`userId\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE
+    ) ENGINE=InnoDB CHARACTER SET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`map_blueprints\` (
+      \`id\` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      \`name\` varchar(255) NOT NULL
+    ) ENGINE=InnoDB CHARACTER SET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`map_node_blueprints\` (
+      \`id\` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      \`kind\` enum('BASE','RESOURCE','DEFENSE','ARMY','SPECIAL') NOT NULL,
+      \`x\` int NOT NULL,
+      \`y\` int NOT NULL,
+      \`blueprintId\` int NULL,
+      CONSTRAINT FK_node_blueprint FOREIGN KEY (\`blueprintId\`) REFERENCES \`map_blueprints\`(\`id\`) ON DELETE CASCADE
+    ) ENGINE=InnoDB CHARACTER SET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`map_edge_blueprints\` (
+      \`id\` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      \`distance\` int NOT NULL,
+      \`blueprintId\` int NULL,
+      \`fromId\` int NULL,
+      \`toId\` int NULL,
+      CONSTRAINT FK_edge_blueprint FOREIGN KEY (\`blueprintId\`) REFERENCES \`map_blueprints\`(\`id\`) ON DELETE CASCADE,
+      CONSTRAINT FK_edge_from FOREIGN KEY (\`fromId\`) REFERENCES \`map_node_blueprints\`(\`id\`) ON DELETE CASCADE,
+      CONSTRAINT FK_edge_to FOREIGN KEY (\`toId\`) REFERENCES \`map_node_blueprints\`(\`id\`) ON DELETE CASCADE
+    ) ENGINE=InnoDB CHARACTER SET=utf8mb4`);
+
+    await queryRunner.query(`INSERT INTO map_blueprints (id, name) VALUES (1, 'Starter 5 Nodes')`);
+    await queryRunner.query(`INSERT INTO map_node_blueprints (id, blueprintId, kind, x, y) VALUES
+      (1,1,'BASE',100,300),
+      (2,1,'RESOURCE',300,250),
+      (3,1,'ARMY',450,320),
+      (4,1,'DEFENSE',600,350),
+      (5,1,'BASE',700,300)`);
+    await queryRunner.query(`INSERT INTO map_edge_blueprints (blueprintId, fromId, toId, distance) VALUES
+      (1,1,2,223),
+      (1,2,3,158),
+      (1,3,4,158),
+      (1,4,5,223),
+      (1,2,4,335)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `map_edge_blueprints`');
+    await queryRunner.query('DROP TABLE `map_node_blueprints`');
+    await queryRunner.query('DROP TABLE `map_blueprints`');
+    await queryRunner.query('DROP TABLE `match_participants`');
+    await queryRunner.query('DROP TABLE `matches`');
+    await queryRunner.query('DROP TABLE `users`');
+  }
+}

--- a/game/server/package.json
+++ b/game/server/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "game-server",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "nest start --watch",
+    "build": "nest build",
+    "mig:gen": "ts-node ./node_modules/typeorm/cli.js migration:generate -d src/migrations -n init",
+    "mig:run": "ts-node ./node_modules/typeorm/cli.js migration:run",
+    "mig:revert": "ts-node ./node_modules/typeorm/cli.js migration:revert"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/websockets": "^10.0.0",
+    "@nestjs/platform-socket.io": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
+    "@nestjs/jwt": "^10.0.0",
+    "bcrypt": "^5.1.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "jsonwebtoken": "^9.0.0",
+    "mysql2": "^3.6.0",
+    "socket.io": "^4.7.2",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@types/bcrypt": "^5.0.0",
+    "@types/jsonwebtoken": "^9.0.0",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/game/server/src/app.module.ts
+++ b/game/server/src/app.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { AppDataSource } from '../data-source';
+import { User } from './users/user.entity';
+import { Match } from './matches/match.entity';
+import { MatchParticipant } from './matches/match-participant.entity';
+import { MapBlueprint } from './maps/map-blueprint.entity';
+import { MapNodeBlueprint } from './maps/map-node-blueprint.entity';
+import { MapEdgeBlueprint } from './maps/map-edge-blueprint.entity';
+import { AuthModule } from './auth/auth.module';
+import { MapsModule } from './maps/maps.module';
+import { WsModule } from './ws/ws.module';
+import { HealthController } from './common/health.controller';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRootAsync({
+      useFactory: () => ({ ...AppDataSource.options, autoLoadEntities: true }),
+    }),
+    TypeOrmModule.forFeature([User, Match, MatchParticipant, MapBlueprint, MapNodeBlueprint, MapEdgeBlueprint]),
+    AuthModule,
+    MapsModule,
+    WsModule,
+  ],
+  controllers: [HealthController],
+})
+export class AppModule {}

--- a/game/server/src/auth/auth.controller.ts
+++ b/game/server/src/auth/auth.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private auth: AuthService) {}
+
+  @Post('guest')
+  guestLogin() {
+    return this.auth.loginGuest();
+  }
+}

--- a/game/server/src/auth/auth.module.ts
+++ b/game/server/src/auth/auth.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../users/user.entity';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtStrategy } from './jwt.strategy';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+@Module({
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([User]),
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get('JWT_SECRET'),
+        signOptions: { expiresIn: config.get('JWT_EXPIRES') }
+      })
+    })
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService]
+})
+export class AuthModule {}

--- a/game/server/src/auth/auth.service.ts
+++ b/game/server/src/auth/auth.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/user.entity';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private jwt: JwtService,
+    @InjectRepository(User) private users: Repository<User>,
+    private config: ConfigService
+  ) {}
+
+  async loginGuest() {
+    // find unique guest nickname
+    let nickname: string;
+    let user: User | null = null;
+    do {
+      nickname = 'Guest' + Math.floor(Math.random() * 10000).toString().padStart(4, '0');
+      user = await this.users.findOne({ where: { nickname } });
+    } while (user);
+
+    user = this.users.create({ nickname });
+    await this.users.save(user);
+
+    const payload = { sub: user.id, nickname: user.nickname };
+    const token = await this.jwt.signAsync(payload);
+    return { token, user };
+  }
+}

--- a/game/server/src/auth/jwt.strategy.ts
+++ b/game/server/src/auth/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(config: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: config.get('JWT_SECRET'),
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub, nickname: payload.nickname };
+  }
+}

--- a/game/server/src/common/health.controller.ts
+++ b/game/server/src/common/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class HealthController {
+  @Get('health')
+  health() {
+    return { status: 'ok', time: new Date().toISOString() };
+    }
+}

--- a/game/server/src/common/types.ts
+++ b/game/server/src/common/types.ts
@@ -1,0 +1,13 @@
+export type Team = 'A' | 'B';
+export type NodeKind = 'BASE' | 'RESOURCE' | 'DEFENSE' | 'ARMY' | 'SPECIAL';
+
+export interface MapNode { id: number; kind: NodeKind; x: number; y: number; }
+export interface MapEdge { from: number; to: number; distance: number; }
+export interface MatchPlayer { userId: string; nickname: string; team: Team; }
+export interface NodeState { nodeId: number; owner: Team | null; garrison: number; }
+export interface MatchState {
+  matchId: string;
+  players: MatchPlayer[];
+  map: { blueprintId: number; nodes: MapNode[]; edges: MapEdge[] };
+  nodesState: NodeState[];
+}

--- a/game/server/src/main.ts
+++ b/game/server/src/main.ts
@@ -1,0 +1,13 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const config = app.get(ConfigService);
+  app.enableCors({ origin: config.get('CORS_ORIGIN') });
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  await app.listen(config.get<number>('PORT') || 3000);
+}
+bootstrap();

--- a/game/server/src/maps/map-blueprint.entity.ts
+++ b/game/server/src/maps/map-blueprint.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { MapNodeBlueprint } from './map-node-blueprint.entity';
+import { MapEdgeBlueprint } from './map-edge-blueprint.entity';
+
+@Entity('map_blueprints')
+export class MapBlueprint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @OneToMany(() => MapNodeBlueprint, (n) => n.blueprint, { eager: true })
+  nodes: MapNodeBlueprint[];
+
+  @OneToMany(() => MapEdgeBlueprint, (e) => e.blueprint, { eager: true })
+  edges: MapEdgeBlueprint[];
+}

--- a/game/server/src/maps/map-edge-blueprint.entity.ts
+++ b/game/server/src/maps/map-edge-blueprint.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+import { MapNodeBlueprint } from './map-node-blueprint.entity';
+
+@Entity('map_edge_blueprints')
+export class MapEdgeBlueprint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => MapBlueprint, (b) => b.edges, { onDelete: 'CASCADE' })
+  blueprint: MapBlueprint;
+
+  @ManyToOne(() => MapNodeBlueprint, { onDelete: 'CASCADE' })
+  from: MapNodeBlueprint;
+
+  @ManyToOne(() => MapNodeBlueprint, { onDelete: 'CASCADE' })
+  to: MapNodeBlueprint;
+
+  @Column('int')
+  distance: number;
+}

--- a/game/server/src/maps/map-node-blueprint.entity.ts
+++ b/game/server/src/maps/map-node-blueprint.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+import { NodeKind } from '../common/types';
+
+@Entity('map_node_blueprints')
+export class MapNodeBlueprint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => MapBlueprint, (b) => b.nodes, { onDelete: 'CASCADE' })
+  blueprint: MapBlueprint;
+
+  @Column({ type: 'enum', enum: ['BASE','RESOURCE','DEFENSE','ARMY','SPECIAL'] })
+  kind: NodeKind;
+
+  @Column('int')
+  x: number;
+
+  @Column('int')
+  y: number;
+}

--- a/game/server/src/maps/maps.controller.ts
+++ b/game/server/src/maps/maps.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+
+@Controller('maps')
+export class MapsController {
+  constructor(@InjectRepository(MapBlueprint) private repo: Repository<MapBlueprint>) {}
+
+  @Get('blueprints/:id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.repo.findOne({ where: { id } });
+  }
+}

--- a/game/server/src/maps/maps.module.ts
+++ b/game/server/src/maps/maps.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+import { MapNodeBlueprint } from './map-node-blueprint.entity';
+import { MapEdgeBlueprint } from './map-edge-blueprint.entity';
+import { MapsController } from './maps.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MapBlueprint, MapNodeBlueprint, MapEdgeBlueprint])],
+  controllers: [MapsController]
+})
+export class MapsModule {}

--- a/game/server/src/matches/match-participant.entity.ts
+++ b/game/server/src/matches/match-participant.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { Match } from './match.entity';
+import { User } from '../users/user.entity';
+import { Team } from '../common/types';
+
+@Entity('match_participants')
+export class MatchParticipant {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Match, (match) => match.participants, { onDelete: 'CASCADE' })
+  match: Match;
+
+  @ManyToOne(() => User, { eager: true, onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ type: 'enum', enum: ['A', 'B'] })
+  team: Team;
+
+  @CreateDateColumn({ name: 'joined_at' })
+  joinedAt: Date;
+}

--- a/game/server/src/matches/match.entity.ts
+++ b/game/server/src/matches/match.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, OneToMany } from 'typeorm';
+import { MatchParticipant } from './match-participant.entity';
+
+export type MatchStatus = 'WAITING' | 'RUNNING' | 'FINISHED';
+
+@Entity('matches')
+export class Match {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'enum', enum: ['WAITING', 'RUNNING', 'FINISHED'], default: 'WAITING' })
+  status: MatchStatus;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @OneToMany(() => MatchParticipant, (p) => p.match)
+  participants: MatchParticipant[];
+}

--- a/game/server/src/users/user.entity.ts
+++ b/game/server/src/users/user.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  nickname: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/game/server/src/ws/ws.gateway.ts
+++ b/game/server/src/ws/ws.gateway.ts
@@ -1,0 +1,104 @@
+import {
+  WebSocketGateway,
+  SubscribeMessage,
+  MessageBody,
+  ConnectedSocket,
+  WebSocketServer
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { Match } from '../matches/match.entity';
+import { MatchParticipant } from '../matches/match-participant.entity';
+import { MapBlueprint } from '../maps/map-blueprint.entity';
+import { MapNodeBlueprint } from '../maps/map-node-blueprint.entity';
+import { MapEdgeBlueprint } from '../maps/map-edge-blueprint.entity';
+import { User } from '../users/user.entity';
+import { MatchState, NodeState, Team } from '../common/types';
+
+@WebSocketGateway({ namespace: '/', path: '/ws' })
+export class LobbyGateway {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    @InjectRepository(Match) private matches: Repository<Match>,
+    @InjectRepository(MatchParticipant) private participants: Repository<MatchParticipant>,
+    @InjectRepository(MapBlueprint) private blueprints: Repository<MapBlueprint>,
+    @InjectRepository(MapNodeBlueprint) private nodeRepo: Repository<MapNodeBlueprint>,
+    @InjectRepository(MapEdgeBlueprint) private edgeRepo: Repository<MapEdgeBlueprint>,
+    @InjectRepository(User) private users: Repository<User>,
+    private jwt: JwtService
+  ) {}
+
+  private async getMatchState(match: Match): Promise<MatchState> {
+    const players = await this.participants.find({ where: { match: { id: match.id } }, relations: ['user'] });
+    const map = await this.blueprints.findOne({ where: { id: 1 }, relations: ['nodes', 'edges'] });
+    const nodesState: NodeState[] = map.nodes.map((n) => ({
+      nodeId: n.id,
+      owner: n.id === 1 ? 'A' : n.id === 5 ? 'B' : null,
+      garrison: 0
+    }));
+    return {
+      matchId: match.id,
+      players: players.map((p) => ({ userId: p.user.id, nickname: p.user.nickname, team: p.team })),
+      map: { blueprintId: map.id, nodes: map.nodes, edges: map.edges },
+      nodesState
+    };
+  }
+
+  @SubscribeMessage('lobby:create')
+  async create(@MessageBody() body: { mapBlueprintId: number }, @ConnectedSocket() socket: Socket) {
+    const token = socket.handshake.query['auth.token'] as string | undefined;
+    let user: User = null;
+    try {
+      const payload: any = token ? this.jwt.verify(token) : null;
+      user = payload ? await this.users.findOne({ where: { id: payload.sub } }) : null;
+    } catch {
+      return { ok: false };
+    }
+    if (!user) return { ok: false };
+
+    const match = await this.matches.save(this.matches.create({ status: 'WAITING' }));
+    const participant = this.participants.create({ match, user, team: 'A' });
+    await this.participants.save(participant);
+    socket.join(`match:${match.id}`);
+    return { ok: true, matchId: match.id };
+  }
+
+  @SubscribeMessage('lobby:join')
+  async join(@MessageBody() body: { matchId: string }, @ConnectedSocket() socket: Socket) {
+    const token = socket.handshake.query['auth.token'] as string | undefined;
+    let user: User = null;
+    try {
+      const payload: any = token ? this.jwt.verify(token) : null;
+      user = payload ? await this.users.findOne({ where: { id: payload.sub } }) : null;
+    } catch {
+      return { ok: false };
+    }
+    if (!user) return { ok: false };
+
+    const match = await this.matches.findOne({ where: { id: body.matchId } });
+    if (!match || match.status !== 'WAITING') return { ok: false };
+    const existing = await this.participants.find({ where: { match: { id: match.id } } });
+    if (existing.find((p) => p.user.id === user.id)) {
+      // already joined
+    } else if (existing.length >= 2) {
+      return { ok: false };
+    } else {
+      const team: Team = existing.find((p) => p.team === 'A') ? 'B' : 'A';
+      await this.participants.save(this.participants.create({ match, user, team }));
+    }
+    socket.join(`match:${match.id}`);
+    const state = await this.getMatchState(match);
+    return { ok: true, state };
+  }
+
+  @SubscribeMessage('lobby:leave')
+  leave(@ConnectedSocket() socket: Socket) {
+    // Simply leave all rooms except own id
+    Object.keys(socket.rooms).forEach((room) => { if (room !== socket.id) socket.leave(room); });
+    return { ok: true };
+  }
+}

--- a/game/server/src/ws/ws.module.ts
+++ b/game/server/src/ws/ws.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { LobbyGateway } from './ws.gateway';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Match } from '../matches/match.entity';
+import { MatchParticipant } from '../matches/match-participant.entity';
+import { MapBlueprint } from '../maps/map-blueprint.entity';
+import { MapNodeBlueprint } from '../maps/map-node-blueprint.entity';
+import { MapEdgeBlueprint } from '../maps/map-edge-blueprint.entity';
+import { User } from '../users/user.entity';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+@Module({
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([Match, MatchParticipant, MapBlueprint, MapNodeBlueprint, MapEdgeBlueprint, User]),
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({ secret: config.get('JWT_SECRET') })
+    })
+  ],
+  providers: [LobbyGateway]
+})
+export class WsModule {}

--- a/game/server/tsconfig.json
+++ b/game/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "src",
+    "incremental": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up NestJS server with REST endpoints, JWT guest auth, and Socket.IO lobby gateway
- scaffold Vue 3 client with guest login, lobby, and match view rendering map blueprints

## Testing
- `cd game/server && npm test` (fails: Missing script "test")
- `cd game/client && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a4bb2b1644832ca757d56ee64abf08