### PR TITLE
Add match runtime, troop dispatch, and client map interaction

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -1,0 +1,23 @@
+# Game Mono Repo
+
+Monorepo containing `server` (NestJS) and `client` (Vue 3). Provides guest login, lobby creation and joining with basic map display.
+
+## Shared Structures
+
+```
+Team: 'A' | 'B'
+NodeKind: 'BASE' | 'RESOURCE' | 'DEFENSE' | 'ARMY' | 'SPECIAL'
+
+Map: {
+  blueprintId: number,
+  nodes: { id:number, kind:NodeKind, x:number, y:number }[],
+  edges: { from:number, to:number, distance:number }[]
+}
+
+MatchState: {
+  matchId: string,
+  players: { userId:string, nickname:string, team:Team }[],
+  map: Map,
+  nodesState: { nodeId:number, owner:Team|null, garrison:number }[]
+}
+```

--- a/game/client/index.html
+++ b/game/client/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Game</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/game/client/package.json
+++ b/game/client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "game-client",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.3.0",
+    "vue-router": "^4.2.0",
+    "pinia": "^2.1.0",
+    "axios": "^1.5.0",
+    "socket.io-client": "^4.7.0"
+  },
+  "devDependencies": {
+    "vite": "^4.4.0",
+    "@vitejs/plugin-vue": "^4.2.0"
+  }
+}

--- a/game/client/src/api/http.js
+++ b/game/client/src/api/http.js
@@ -1,0 +1,14 @@
+import axios from 'axios'
+import { useAuthStore } from '../store/auth'
+
+const http = axios.create({ baseURL: 'http://localhost:3000' })
+
+http.interceptors.request.use((config) => {
+  const auth = useAuthStore()
+  if (auth.token) {
+    config.headers.Authorization = `Bearer ${auth.token}`
+  }
+  return config
+})
+
+export default http

--- a/game/client/src/app.vue
+++ b/game/client/src/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <router-view />
+</template>

--- a/game/client/src/components/MapCanvas.vue
+++ b/game/client/src/components/MapCanvas.vue
@@ -1,0 +1,119 @@
+<template>
+  <svg viewBox="0 0 800 600" style="border:1px solid #ccc" @click="cancel">
+    <g v-if="map">
+      <line
+        v-for="e in map.edges"
+        :key="e.from+'-'+e.to"
+        :x1="nodeById(e.from).x"
+        :y1="nodeById(e.from).y"
+        :x2="nodeById(e.to).x"
+        :y2="nodeById(e.to).y"
+        stroke="#999"
+      />
+      <g v-for="n in map.nodes" :key="n.id">
+        <circle
+          :cx="n.x"
+          :cy="n.y"
+          r="20"
+          :fill="color(n.id)"
+          stroke="#000"
+          :stroke-width="selectedFrom === n.id ? 4 : 1"
+          @click.stop="onNode(n.id)"
+        />
+        <text :x="n.x" :y="n.y - 25" font-size="12" text-anchor="middle">{{ n.kind }}</text>
+        <text :x="n.x" :y="n.y + 5" font-size="12" text-anchor="middle">{{ garrison(n.id) }}</text>
+      </g>
+      <g v-for="c in convoys" :key="c.id">
+        <circle :cx="convoyPos(c).x" :cy="convoyPos(c).y" r="8" :fill="c.team==='A' ? 'blue' : 'red'" />
+        <text :x="convoyPos(c).x" :y="convoyPos(c).y - 10" font-size="10" text-anchor="middle">{{ c.total }}</text>
+      </g>
+      <g v-if="pendingTo">
+        <g :transform="`translate(${panelPos.x - 30}, ${panelPos.y - 60})`">
+          <rect width="60" height="40" fill="#fff" stroke="#000" />
+          <text x="5" y="15" font-size="12" @click.stop="send(25)">25%</text>
+          <text x="25" y="15" font-size="12" @click.stop="send(50)">50%</text>
+          <text x="45" y="15" font-size="12" @click.stop="send(100)">100%</text>
+        </g>
+      </g>
+    </g>
+  </svg>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { matchStore } from '../store/match'
+
+const props = defineProps({
+  map: Object,
+  nodesState: Array,
+  convoys: Array,
+  myTeam: String,
+  now: Number
+})
+
+const selectedFrom = ref(null)
+const pendingTo = ref(null)
+
+function nodeById(id) {
+  return props.map.nodes.find(n => n.id === id)
+}
+
+function stateById(id) {
+  return props.nodesState.find(n => n.nodeId === id)
+}
+
+function color(nodeId) {
+  const state = stateById(nodeId)
+  if (!state || !state.owner) return '#ccc'
+  return state.owner === 'A' ? 'blue' : 'red'
+}
+
+function garrison(nodeId) {
+  const st = stateById(nodeId)
+  return st ? Math.floor(st.garrison) : 0
+}
+
+function isAdj(a, b) {
+  return props.map.edges.some(e => (e.from === a && e.to === b) || (e.from === b && e.to === a))
+}
+
+function onNode(id) {
+  const st = stateById(id)
+  if (!selectedFrom.value) {
+    if (st && st.owner === props.myTeam) selectedFrom.value = id
+  } else {
+    if (id === selectedFrom.value) {
+      selectedFrom.value = null
+    } else if (isAdj(selectedFrom.value, id)) {
+      pendingTo.value = id
+    } else {
+      selectedFrom.value = null
+    }
+  }
+}
+
+function send(percent) {
+  matchStore.sendTroops({ fromNodeId: selectedFrom.value, toNodeId: pendingTo.value, percent })
+  pendingTo.value = null
+  selectedFrom.value = null
+}
+
+function cancel() {
+  selectedFrom.value = null
+  pendingTo.value = null
+}
+
+const panelPos = computed(() => {
+  if (!pendingTo.value) return { x: 0, y: 0 }
+  const n = nodeById(pendingTo.value)
+  return { x: n.x, y: n.y }
+})
+
+function convoyPos(c) {
+  const from = nodeById(c.from)
+  const to = nodeById(c.to)
+  const p = Math.min(1, Math.max(0, (props.now - c.departAt) / (c.arriveAt - c.departAt)))
+  return { x: from.x + (to.x - from.x) * p, y: from.y + (to.y - from.y) * p }
+}
+
+</script>

--- a/game/client/src/main.js
+++ b/game/client/src/main.js
@@ -1,0 +1,9 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import router from './router'
+import App from './app.vue'
+
+const app = createApp(App)
+app.use(createPinia())
+app.use(router)
+app.mount('#app')

--- a/game/client/src/pages/Lobby.vue
+++ b/game/client/src/pages/Lobby.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <div>
+      <input v-model="matchId" placeholder="match id" />
+      <button @click="create">Создать матч</button>
+      <button @click="join">Войти</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSocketStore } from '../store/socket'
+
+const router = useRouter()
+const socket = useSocketStore()
+const matchId = ref('')
+
+if (!socket.socket) socket.init()
+
+async function create() {
+  const res = await socket.emitAck('lobby:create', { mapBlueprintId: 1 })
+  matchId.value = res.matchId
+  router.push({ path: '/match', query: { matchId: res.matchId } })
+}
+
+async function join() {
+  router.push({ path: '/match', query: { matchId: matchId.value } })
+}
+</script>

--- a/game/client/src/pages/LoginGuest.vue
+++ b/game/client/src/pages/LoginGuest.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="login">
+    <button @click="login">Войти гостем</button>
+  </div>
+</template>
+
+<script setup>
+import { useAuthStore } from '../store/auth'
+import { useRouter } from 'vue-router'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+async function login() {
+  await auth.loginGuest()
+  router.push('/lobby')
+}
+</script>

--- a/game/client/src/pages/Match.vue
+++ b/game/client/src/pages/Match.vue
@@ -1,0 +1,32 @@
+<template>
+  <div v-if="match.state.map">
+    <h3>Match {{ match.state.matchId }}</h3>
+    <MapCanvas
+      :map="match.state.map"
+      :nodesState="match.state.nodesState"
+      :convoys="match.state.convoys"
+      :myTeam="match.state.myTeam"
+      :now="match.state.now"
+    />
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { useSocketStore } from '../store/socket'
+import { useAuthStore } from '../store/auth'
+import { matchStore as match } from '../store/match'
+import MapCanvas from '../components/MapCanvas.vue'
+
+const route = useRoute()
+const socket = useSocketStore()
+const auth = useAuthStore()
+
+onMounted(async () => {
+  if (!socket.socket) socket.init()
+  socket.onMatchState((payload) => match.onBroadcast(payload))
+  const res = await socket.emitAck('lobby:join', { matchId: route.query.matchId })
+  if (res.ok) match.setInitial(res.state, auth.user.id)
+})
+</script>

--- a/game/client/src/router.js
+++ b/game/client/src/router.js
@@ -1,0 +1,18 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import LoginGuest from './pages/LoginGuest.vue'
+import Lobby from './pages/Lobby.vue'
+import Match from './pages/Match.vue'
+
+const routes = [
+  { path: '/', redirect: '/login' },
+  { path: '/login', component: LoginGuest },
+  { path: '/lobby', component: Lobby },
+  { path: '/match', component: Match }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+export default router

--- a/game/client/src/store/auth.js
+++ b/game/client/src/store/auth.js
@@ -1,0 +1,13 @@
+import { defineStore } from 'pinia'
+import http from '../api/http'
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({ token: '', user: null }),
+  actions: {
+    async loginGuest() {
+      const res = await http.post('/auth/guest')
+      this.token = res.data.token
+      this.user = res.data.user
+    }
+  }
+})

--- a/game/client/src/store/match.js
+++ b/game/client/src/store/match.js
@@ -1,0 +1,36 @@
+import { reactive } from 'vue'
+import { useSocketStore } from './socket'
+
+export const matchStore = {
+  state: reactive({
+    myTeam: null,
+    map: null,
+    nodesState: [],
+    convoys: [],
+    now: Date.now(),
+    matchId: null
+  }),
+  setInitial(state, userId) {
+    this.state.matchId = state.matchId
+    this.state.map = state.map
+    this.state.nodesState = state.nodesState
+    this.state.convoys = state.convoys || []
+    const me = state.players.find(p => p.userId === userId)
+    this.state.myTeam = me ? me.team : null
+    this.state.now = Date.now()
+  },
+  onBroadcast(payload) {
+    this.state.nodesState = payload.nodesState
+    this.state.convoys = payload.convoys
+    this.state.now = payload.now
+  },
+  async sendTroops({ fromNodeId, toNodeId, percent }) {
+    const socket = useSocketStore()
+    return await socket.emitAck('match:sendTroops', {
+      matchId: this.state.matchId,
+      fromNodeId,
+      toNodeId,
+      percent
+    })
+  }
+}

--- a/game/client/src/store/socket.js
+++ b/game/client/src/store/socket.js
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+import { io } from 'socket.io-client'
+import { useAuthStore } from './auth'
+
+export const useSocketStore = defineStore('socket', {
+  state: () => ({ socket: null }),
+  actions: {
+    init() {
+      const auth = useAuthStore()
+      this.socket = io('http://localhost:3000', {
+        path: '/ws',
+        query: { 'auth.token': auth.token }
+      })
+    },
+    emitAck(event, payload) {
+      return new Promise((resolve) => {
+        this.socket.emit(event, payload, (res) => resolve(res))
+      })
+    },
+    onMatchState(cb) {
+      if (this.socket) this.socket.on('match:state', cb)
+    }
+  }
+})

--- a/game/client/vite.config.js
+++ b/game/client/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+export default defineConfig({
+  plugins: [vue()],
+  server: { port: 5173 }
+})

--- a/game/pnpm-workspace.yaml
+++ b/game/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'server'
+  - 'client'

--- a/game/server/.env.example
+++ b/game/server/.env.example
@@ -1,0 +1,11 @@
+PORT=3000
+CORS_ORIGIN=http://localhost:5173
+
+JWT_SECRET=dev_secret_change_me
+JWT_EXPIRES=7d
+
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_USER=root
+DB_PASS=
+DB_NAME=game

--- a/game/server/migrations/1680000000000-init.ts
+++ b/game/server/migrations/1680000000000-init.ts
@@ -1,0 +1,74 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Init1680000000000 implements MigrationInterface {
+  name = 'Init1680000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE \`users\` (
+  \`id\` char(36) NOT NULL PRIMARY KEY,
+  \`nickname\` varchar(255) UNIQUE NOT NULL,
+  \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`matches\` (
+  \`id\` char(36) NOT NULL PRIMARY KEY,
+  \`status\` enum('WAITING','RUNNING','FINISHED') NOT NULL DEFAULT 'WAITING',
+  \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  \`mapBlueprintId\` int NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`match_participants\` (
+  \`id\` char(36) NOT NULL PRIMARY KEY,
+  \`team\` enum('A','B') NOT NULL,
+  \`joined_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  \`matchId\` char(36) NULL,
+  \`userId\` char(36) NULL,
+  INDEX (\`matchId\`), INDEX (\`userId\`),
+  CONSTRAINT \`fk_match\` FOREIGN KEY (\`matchId\`) REFERENCES \`matches\`(\`id\`) ON DELETE CASCADE,
+  CONSTRAINT \`fk_user\` FOREIGN KEY (\`userId\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`map_blueprints\` (
+  \`id\` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  \`name\` varchar(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`map_node_blueprints\` (
+  \`id\` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  \`kind\` enum('BASE','RESOURCE','DEFENSE','ARMY','SPECIAL') NOT NULL,
+  \`x\` int NOT NULL,
+  \`y\` int NOT NULL,
+  \`blueprintId\` int NULL, INDEX (\`blueprintId\`),
+  CONSTRAINT \`fk_node_bp\` FOREIGN KEY (\`blueprintId\`) REFERENCES \`map_blueprints\`(\`id\`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+    await queryRunner.query(`CREATE TABLE \`map_edge_blueprints\` (
+  \`id\` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  \`distance\` int NOT NULL,
+  \`blueprintId\` int NULL,
+  \`fromId\` int NULL,
+  \`toId\` int NULL, INDEX (\`blueprintId\`), INDEX (\`fromId\`), INDEX (\`toId\`),
+  CONSTRAINT \`fk_edge_bp\` FOREIGN KEY (\`blueprintId\`) REFERENCES \`map_blueprints\`(\`id\`) ON DELETE CASCADE,
+  CONSTRAINT \`fk_edge_from\` FOREIGN KEY (\`fromId\`) REFERENCES \`map_node_blueprints\`(\`id\`) ON DELETE CASCADE,
+  CONSTRAINT \`fk_edge_to\` FOREIGN KEY (\`toId\`) REFERENCES \`map_node_blueprints\`(\`id\`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+    await queryRunner.query(`INSERT INTO map_blueprints (id,name) VALUES (1,'Starter 5 Nodes')`);
+    await queryRunner.query(`INSERT INTO map_node_blueprints (id,blueprintId,kind,x,y) VALUES
+      (1,1,'BASE',100,300),
+      (2,1,'RESOURCE',300,250),
+      (3,1,'ARMY',450,320),
+      (4,1,'DEFENSE',600,350),
+      (5,1,'BASE',700,300)`);
+    await queryRunner.query(`INSERT INTO map_edge_blueprints (blueprintId,fromId,toId,distance) VALUES
+      (1,1,2,206),
+      (1,2,3,165),
+      (1,3,4,153),
+      (1,4,5,112),
+      (1,2,4,316)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `map_edge_blueprints`');
+    await queryRunner.query('DROP TABLE `map_node_blueprints`');
+    await queryRunner.query('DROP TABLE `map_blueprints`');
+    await queryRunner.query('DROP TABLE `match_participants`');
+    await queryRunner.query('DROP TABLE `matches`');
+    await queryRunner.query('DROP TABLE `users`');
+  }
+}
+

--- a/game/server/package.json
+++ b/game/server/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "game-server",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "nest start --watch",
+    "build": "nest build",
+    "start:prod": "node dist/main.js",
+    "mig:run": "npx typeorm migration:run -d src/data-source.ts",
+    "mig:revert": "npx typeorm migration:revert -d src/data-source.ts",
+    "mig:gen": "npx typeorm migration:generate src/migrations/auto -d src/data-source.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/websockets": "^10.0.0",
+    "@nestjs/platform-socket.io": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
+    "class-validator": "^0.14.0",
+    "class-transformer": "^0.5.1",
+    "@nestjs/jwt": "^10.0.0",
+    "jsonwebtoken": "^9.0.0",
+    "bcrypt": "^5.1.0",
+    "typeorm": "^0.3.17",
+    "mysql2": "^3.2.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.9.1",
+    "@types/node": "^20.0.0",
+    "@types/jsonwebtoken": "^9.0.0",
+    "@types/bcrypt": "^5.0.0"
+  }
+}

--- a/game/server/src/app.module.ts
+++ b/game/server/src/app.module.ts
@@ -1,0 +1,48 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { User } from './users/user.entity';
+import { MapBlueprint } from './maps/map-blueprint.entity';
+import { MapNodeBlueprint } from './maps/map-node-blueprint.entity';
+import { MapEdgeBlueprint } from './maps/map-edge-blueprint.entity';
+import { Match } from './matches/match.entity';
+import { MatchParticipant } from './matches/match-participant.entity';
+import { AuthModule } from './auth/auth.module';
+import { MapsModule } from './maps/maps.module';
+import { WsGateway } from './ws/ws.gateway';
+import { RuntimeService } from './matches/runtime.service';
+import { HealthController } from './common/health.controller';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (cfg: ConfigService) => ({
+        type: 'mysql',
+        host: cfg.get('DB_HOST'),
+        port: parseInt(cfg.get('DB_PORT') || '3306'),
+        username: cfg.get('DB_USER'),
+        password: cfg.get('DB_PASS'),
+        database: cfg.get('DB_NAME'),
+        entities: [User, MapBlueprint, MapNodeBlueprint, MapEdgeBlueprint, Match, MatchParticipant],
+        synchronize: false,
+        charset: 'utf8mb4',
+      }),
+    }),
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (cfg: ConfigService) => ({
+        secret: cfg.get('JWT_SECRET'),
+        signOptions: { expiresIn: cfg.get('JWT_EXPIRES') },
+      }),
+    }),
+    TypeOrmModule.forFeature([User, Match, MatchParticipant]),
+    AuthModule,
+    MapsModule,
+  ],
+  controllers: [HealthController],
+  providers: [WsGateway, RuntimeService],
+})
+export class AppModule {}

--- a/game/server/src/auth/auth.controller.ts
+++ b/game/server/src/auth/auth.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private auth: AuthService) {}
+
+  @Post('guest')
+  async guest() {
+    return this.auth.loginGuest();
+  }
+}

--- a/game/server/src/auth/auth.module.ts
+++ b/game/server/src/auth/auth.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../users/user.entity';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User]), JwtModule.register({})],
+  providers: [AuthService],
+  controllers: [AuthController],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/game/server/src/auth/auth.service.ts
+++ b/game/server/src/auth/auth.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/user.entity';
+import { JwtService } from '@nestjs/jwt';
+import { randomInt } from 'crypto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(User) private users: Repository<User>,
+    private jwt: JwtService,
+  ) {}
+
+  async loginGuest() {
+    let nickname: string;
+    let user: User | null = null;
+    while (!user) {
+      nickname = `Guest${randomInt(1000, 9999)}`;
+      user = await this.users.findOne({ where: { nickname } });
+      if (!user) {
+        user = this.users.create({ nickname });
+        user = await this.users.save(user);
+      }
+    }
+    const token = await this.jwt.signAsync({ sub: user.id });
+    return { token, user: { id: user.id, nickname: user.nickname } };
+  }
+}

--- a/game/server/src/common/health.controller.ts
+++ b/game/server/src/common/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  health() {
+    return { status: 'ok', time: new Date().toISOString() };
+    }
+}

--- a/game/server/src/common/types.ts
+++ b/game/server/src/common/types.ts
@@ -1,0 +1,1 @@
+export type Team = 'A' | 'B';

--- a/game/server/src/data-source.ts
+++ b/game/server/src/data-source.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+import { User } from './users/user.entity';
+import { Match } from './matches/match.entity';
+import { MatchParticipant } from './matches/match-participant.entity';
+import { MapBlueprint } from './maps/map-blueprint.entity';
+import { MapNodeBlueprint } from './maps/map-node-blueprint.entity';
+import { MapEdgeBlueprint } from './maps/map-edge-blueprint.entity';
+
+export const AppDataSource = new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT || '3306'),
+  username: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME,
+  entities: [User, Match, MatchParticipant, MapBlueprint, MapNodeBlueprint, MapEdgeBlueprint],
+  migrations: [__dirname + '/../migrations/*{.ts,.js}'],
+  synchronize: false,
+  charset: 'utf8mb4',
+});
+
+export default AppDataSource;

--- a/game/server/src/main.ts
+++ b/game/server/src/main.ts
@@ -1,0 +1,13 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ConfigService } from '@nestjs/config';
+import { ValidationPipe } from '@nestjs/common';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const config = app.get(ConfigService);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.enableCors({ origin: config.get('CORS_ORIGIN') });
+  await app.listen(config.get('PORT') || 3000);
+}
+bootstrap();

--- a/game/server/src/maps/map-blueprint.entity.ts
+++ b/game/server/src/maps/map-blueprint.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { MapNodeBlueprint } from './map-node-blueprint.entity';
+import { MapEdgeBlueprint } from './map-edge-blueprint.entity';
+
+@Entity('map_blueprints')
+export class MapBlueprint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @OneToMany(() => MapNodeBlueprint, (n) => n.blueprint)
+  nodes: MapNodeBlueprint[];
+
+  @OneToMany(() => MapEdgeBlueprint, (e) => e.blueprint)
+  edges: MapEdgeBlueprint[];
+}

--- a/game/server/src/maps/map-edge-blueprint.entity.ts
+++ b/game/server/src/maps/map-edge-blueprint.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+import { MapNodeBlueprint } from './map-node-blueprint.entity';
+
+@Entity('map_edge_blueprints')
+export class MapEdgeBlueprint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => MapBlueprint, (bp) => bp.edges, { onDelete: 'CASCADE' })
+  blueprint: MapBlueprint;
+
+  @ManyToOne(() => MapNodeBlueprint, { onDelete: 'CASCADE' })
+  from: MapNodeBlueprint;
+
+  @ManyToOne(() => MapNodeBlueprint, { onDelete: 'CASCADE' })
+  to: MapNodeBlueprint;
+
+  @Column('int')
+  distance: number;
+}

--- a/game/server/src/maps/map-node-blueprint.entity.ts
+++ b/game/server/src/maps/map-node-blueprint.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+
+export type NodeKind = 'BASE' | 'RESOURCE' | 'DEFENSE' | 'ARMY' | 'SPECIAL';
+
+@Entity('map_node_blueprints')
+export class MapNodeBlueprint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => MapBlueprint, (bp) => bp.nodes, { onDelete: 'CASCADE' })
+  blueprint: MapBlueprint;
+
+  @Column({ type: 'enum', enum: ['BASE', 'RESOURCE', 'DEFENSE', 'ARMY', 'SPECIAL'] })
+  kind: NodeKind;
+
+  @Column('int')
+  x: number;
+
+  @Column('int')
+  y: number;
+}

--- a/game/server/src/maps/maps.controller.ts
+++ b/game/server/src/maps/maps.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { MapsService } from './maps.service';
+
+@Controller('maps')
+export class MapsController {
+  constructor(private maps: MapsService) {}
+
+  @Get('blueprints/:id')
+  async get(@Param('id', ParseIntPipe) id: number) {
+    const bp = await this.maps.getBlueprint(id);
+    if (!bp) return null;
+    return {
+      id: bp.id,
+      name: bp.name,
+      nodes: bp.nodes.map((n) => ({ id: n.id, kind: n.kind, x: n.x, y: n.y })),
+      edges: bp.edges.map((e) => ({ from: e.from.id, to: e.to.id, distance: e.distance })),
+    };
+  }
+}

--- a/game/server/src/maps/maps.module.ts
+++ b/game/server/src/maps/maps.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+import { MapNodeBlueprint } from './map-node-blueprint.entity';
+import { MapEdgeBlueprint } from './map-edge-blueprint.entity';
+import { MapsService } from './maps.service';
+import { MapsController } from './maps.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MapBlueprint, MapNodeBlueprint, MapEdgeBlueprint])],
+  providers: [MapsService],
+  controllers: [MapsController],
+  exports: [MapsService],
+})
+export class MapsModule {}

--- a/game/server/src/maps/maps.service.ts
+++ b/game/server/src/maps/maps.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MapBlueprint } from './map-blueprint.entity';
+
+@Injectable()
+export class MapsService {
+  constructor(@InjectRepository(MapBlueprint) private blueprints: Repository<MapBlueprint>) {}
+
+  async getBlueprint(id: number) {
+    return this.blueprints.findOne({
+      where: { id },
+      relations: { nodes: true, edges: true },
+    });
+  }
+}

--- a/game/server/src/matches/match-participant.entity.ts
+++ b/game/server/src/matches/match-participant.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import { Match } from './match.entity';
+import { User } from '../users/user.entity';
+import { Team } from '../common/types';
+
+@Entity('match_participants')
+export class MatchParticipant {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Match, (m) => m.participants, { onDelete: 'CASCADE' })
+  match: Match;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ type: 'enum', enum: ['A', 'B'] })
+  team: Team;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  joined_at: Date;
+}

--- a/game/server/src/matches/match.entity.ts
+++ b/game/server/src/matches/match.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, OneToMany } from 'typeorm';
+import { MatchParticipant } from './match-participant.entity';
+
+export type MatchStatus = 'WAITING' | 'RUNNING' | 'FINISHED';
+
+@Entity('matches')
+export class Match {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'enum', enum: ['WAITING', 'RUNNING', 'FINISHED'], default: 'WAITING' })
+  status: MatchStatus;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @OneToMany(() => MatchParticipant, (p) => p.match)
+  participants: MatchParticipant[];
+
+  @Column({ type: 'int', nullable: true })
+  mapBlueprintId: number;
+}

--- a/game/server/src/matches/runtime.service.ts
+++ b/game/server/src/matches/runtime.service.ts
@@ -1,0 +1,171 @@
+import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import { MapsService } from '../maps/maps.service';
+import { WsGateway } from '../ws/ws.gateway';
+import { MatchRuntime, Convoy } from './runtime.types';
+import {
+  TICK_RATE,
+  BROADCAST_RATE,
+  UNIT_SPEED,
+  START_GARRISON_BASE,
+  START_GARRISON_OTHER,
+} from '../ws/constants';
+import { randomUUID } from 'crypto';
+import { Team } from '../common/types';
+
+@Injectable()
+export class RuntimeService {
+  private runtimes = new Map<string, MatchRuntime>();
+
+  constructor(
+    private maps: MapsService,
+    @Inject(forwardRef(() => WsGateway)) private ws: WsGateway,
+  ) {}
+
+  getRuntime(matchId: string) {
+    return this.runtimes.get(matchId);
+  }
+
+  async startMatch(matchId: string, blueprintId: number, teams: { A?: string; B?: string }) {
+    const bp = await this.maps.getBlueprint(blueprintId);
+    if (!bp) return;
+    const runtime: MatchRuntime = {
+      matchId,
+      blueprintId,
+      status: 'RUNNING',
+      nodes: new Map(),
+      convoys: new Map(),
+      edges: bp.edges.map((e) => ({ from: e.from.id, to: e.to.id, distance: e.distance })),
+      lastBroadcastAt: Date.now(),
+      lastSendByUser: new Map(),
+      teams,
+    };
+    const baseNodes = bp.nodes.filter((n) => n.kind === 'BASE');
+    for (const n of bp.nodes) {
+      let owner: Team | null = null;
+      let garrison = START_GARRISON_OTHER;
+      let prodPerSec = 0;
+      if (baseNodes[0] && n.id === baseNodes[0].id) {
+        owner = 'A';
+        garrison = START_GARRISON_BASE;
+        prodPerSec = 1;
+      } else if (baseNodes[1] && n.id === baseNodes[1].id) {
+        owner = 'B';
+        garrison = START_GARRISON_BASE;
+        prodPerSec = 1;
+      } else if (n.kind === 'ARMY') {
+        prodPerSec = 0.8;
+      }
+      runtime.nodes.set(n.id, {
+        nodeId: n.id,
+        owner,
+        garrison,
+        prodPerSec,
+      });
+    }
+    runtime.tickHandle = setInterval(() => this.tick(matchId), 1000 / TICK_RATE);
+    runtime.broadcastHandle = setInterval(() => this.broadcast(matchId), 1000 / BROADCAST_RATE);
+    this.runtimes.set(matchId, runtime);
+  }
+
+  stopMatch(matchId: string) {
+    const rt = this.runtimes.get(matchId);
+    if (!rt) return;
+    if (rt.tickHandle) clearInterval(rt.tickHandle);
+    if (rt.broadcastHandle) clearInterval(rt.broadcastHandle);
+    this.runtimes.delete(matchId);
+  }
+
+  tick(matchId: string) {
+    const rt = this.runtimes.get(matchId);
+    if (!rt) return;
+    for (const node of rt.nodes.values()) {
+      node.garrison += node.prodPerSec / TICK_RATE;
+    }
+    const now = Date.now();
+    for (const convoy of Array.from(rt.convoys.values())) {
+      if (now >= convoy.arriveAt) {
+        this.resolveArrival(rt, convoy);
+        rt.convoys.delete(convoy.id);
+      }
+    }
+  }
+
+  private resolveArrival(rt: MatchRuntime, convoy: Convoy) {
+    const dst = rt.nodes.get(convoy.toNodeId);
+    if (!dst) return;
+    if (dst.owner === convoy.team) {
+      dst.garrison += convoy.total;
+    } else if (dst.owner === null) {
+      dst.owner = convoy.team;
+      dst.garrison = convoy.total;
+    } else {
+      const rem = convoy.total - dst.garrison;
+      if (rem > 0) {
+        dst.owner = convoy.team;
+        dst.garrison = rem;
+      } else {
+        dst.garrison = -rem;
+      }
+    }
+  }
+
+  broadcast(matchId: string) {
+    const rt = this.runtimes.get(matchId);
+    if (!rt) return;
+    const now = Date.now();
+    const nodesState = Array.from(rt.nodes.values()).map((n) => ({
+      nodeId: n.nodeId,
+      owner: n.owner,
+      garrison: Math.floor(n.garrison),
+    }));
+    const convoys = Array.from(rt.convoys.values()).map((c) => ({
+      id: c.id,
+      team: c.team,
+      from: c.fromNodeId,
+      to: c.toNodeId,
+      total: c.total,
+      departAt: c.departAt,
+      arriveAt: c.arriveAt,
+    }));
+    this.ws.server.to(`match:${matchId}`).emit('match:state', {
+      now,
+      nodesState,
+      convoys,
+    });
+    rt.lastBroadcastAt = now;
+  }
+
+  isAdjacent(edges: MatchRuntime['edges'], fromId: number, toId: number) {
+    return edges.some(
+      (e) => (e.from === fromId && e.to === toId) || (e.from === toId && e.to === fromId),
+    );
+  }
+
+  createConvoy(
+    rt: MatchRuntime,
+    team: Team,
+    fromNodeId: number,
+    toNodeId: number,
+    qty: number,
+  ) {
+    const now = Date.now();
+    const edge = rt.edges.find(
+      (e) =>
+        (e.from === fromNodeId && e.to === toNodeId) ||
+        (e.from === toNodeId && e.to === fromNodeId),
+    );
+    const dist = edge ? edge.distance : 0;
+    const travelSec = dist / UNIT_SPEED;
+    const convoy: Convoy = {
+      id: randomUUID(),
+      team,
+      fromNodeId,
+      toNodeId,
+      total: qty,
+      departAt: now,
+      arriveAt: now + travelSec * 1000,
+    };
+    rt.convoys.set(convoy.id, convoy);
+    return convoy;
+  }
+}

--- a/game/server/src/matches/runtime.types.ts
+++ b/game/server/src/matches/runtime.types.ts
@@ -1,0 +1,32 @@
+import { Team } from '../common/types';
+
+export interface RuntimeNode {
+  nodeId: number;
+  owner: Team | null;
+  garrison: number;
+  prodPerSec: number;
+}
+
+export interface Convoy {
+  id: string;
+  team: Team;
+  fromNodeId: number;
+  toNodeId: number;
+  total: number;
+  departAt: number;
+  arriveAt: number;
+}
+
+export interface MatchRuntime {
+  matchId: string;
+  blueprintId: number;
+  status: 'WAITING' | 'RUNNING' | 'FINISHED';
+  nodes: Map<number, RuntimeNode>;
+  convoys: Map<string, Convoy>;
+  edges: Array<{ from: number; to: number; distance: number }>;
+  lastBroadcastAt: number;
+  lastSendByUser: Map<string, number>;
+  teams: { A?: string; B?: string };
+  tickHandle?: NodeJS.Timeout;
+  broadcastHandle?: NodeJS.Timeout;
+}

--- a/game/server/src/users/user.entity.ts
+++ b/game/server/src/users/user.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  nickname: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+}

--- a/game/server/src/ws/constants.ts
+++ b/game/server/src/ws/constants.ts
@@ -1,0 +1,6 @@
+export const TICK_RATE = 10;              // 10 тиков/сек
+export const BROADCAST_RATE = 5;          // рассылка 5 раз/сек
+export const UNIT_SPEED = 120;            // пикс/сек
+export const MIN_SEND_COOLDOWN_MS = 150;  // анти-спам
+export const START_GARRISON_BASE = 10;
+export const START_GARRISON_OTHER = 0;

--- a/game/server/src/ws/ws.gateway.ts
+++ b/game/server/src/ws/ws.gateway.ts
@@ -1,0 +1,182 @@
+import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayConnection,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Match } from '../matches/match.entity';
+import { MatchParticipant } from '../matches/match-participant.entity';
+import { MapsService } from '../maps/maps.service';
+import { RuntimeService } from '../matches/runtime.service';
+import { Team } from '../common/types';
+import { MIN_SEND_COOLDOWN_MS } from './constants';
+
+@WebSocketGateway({ path: '/ws', cors: { origin: '*' } })
+@Injectable()
+export class WsGateway implements OnGatewayConnection {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    private jwt: JwtService,
+    @InjectRepository(User) private users: Repository<User>,
+    @InjectRepository(Match) private matches: Repository<Match>,
+    @InjectRepository(MatchParticipant) private parts: Repository<MatchParticipant>,
+    private maps: MapsService,
+    @Inject(forwardRef(() => RuntimeService)) private runtime: RuntimeService,
+  ) {}
+
+  async handleConnection(client: Socket) {
+    const token =
+      (client.handshake.query['auth.token'] as string) ||
+      (client.handshake.headers['authorization']?.split(' ')[1] ?? '');
+    try {
+      const payload = await this.jwt.verifyAsync(token);
+      const user = await this.users.findOne({ where: { id: payload.sub } });
+      if (!user) throw new Error('no user');
+      client.data.user = user;
+    } catch (e) {
+      client.disconnect();
+    }
+  }
+
+  @SubscribeMessage('lobby:create')
+  async create(client: Socket, payload: { mapBlueprintId: number }) {
+    const match = await this.matches.save(
+      this.matches.create({ mapBlueprintId: payload.mapBlueprintId, status: 'WAITING' }),
+    );
+    await this.parts.save(
+      this.parts.create({ match, user: client.data.user, team: 'A' }),
+    );
+    client.join(`match:${match.id}`);
+    return { ok: true, matchId: match.id };
+  }
+
+  @SubscribeMessage('lobby:join')
+  async join(client: Socket, payload: { matchId: string }) {
+    const match = await this.matches.findOne({
+      where: { id: payload.matchId },
+      relations: { participants: { user: true } },
+    });
+    if (!match) return { ok: false };
+    let participant = match.participants.find(
+      (p) => p.user.id === client.data.user.id,
+    );
+    if (!participant) {
+      const team = match.participants.find((p) => p.team === 'A') ? 'B' : 'A';
+      participant = await this.parts.save(
+        this.parts.create({ match, user: client.data.user, team }),
+      );
+      match.participants.push(participant);
+    }
+    client.join(`match:${match.id}`);
+    let runtime = this.runtime.getRuntime(match.id);
+    if (match.status === 'WAITING' && match.participants.length >= 2) {
+      match.status = 'RUNNING';
+      await this.matches.save(match);
+      await this.runtime.startMatch(match.id, match.mapBlueprintId, {
+        A: match.participants.find((p) => p.team === 'A')?.user.id,
+        B: match.participants.find((p) => p.team === 'B')?.user.id,
+      });
+      runtime = this.runtime.getRuntime(match.id);
+    }
+    const bp = await this.maps.getBlueprint(match.mapBlueprintId);
+    const nodesState = runtime
+      ? Array.from(runtime.nodes.values()).map((n) => ({
+          nodeId: n.nodeId,
+          owner: n.owner,
+          garrison: Math.floor(n.garrison),
+        }))
+      : bp.nodes.map((n) => ({ nodeId: n.id, owner: null, garrison: 0 }));
+    const convoys = runtime
+      ? Array.from(runtime.convoys.values()).map((c) => ({
+          id: c.id,
+          team: c.team,
+          from: c.fromNodeId,
+          to: c.toNodeId,
+          total: c.total,
+          departAt: c.departAt,
+          arriveAt: c.arriveAt,
+        }))
+      : [];
+    const players = match.participants.map((p) => ({
+      userId: p.user.id,
+      nickname: p.user.nickname,
+      team: p.team,
+    }));
+    return {
+      ok: true,
+      state: {
+        matchId: match.id,
+        players,
+        map: {
+          blueprintId: bp.id,
+          nodes: bp.nodes.map((n) => ({
+            id: n.id,
+            kind: n.kind,
+            x: n.x,
+            y: n.y,
+          })),
+          edges: bp.edges.map((e) => ({
+            from: e.from.id,
+            to: e.to.id,
+            distance: e.distance,
+          })),
+        },
+        nodesState,
+        convoys,
+      },
+    };
+  }
+
+  @SubscribeMessage('match:sendTroops')
+  async sendTroops(
+    client: Socket,
+    payload: { matchId: string; fromNodeId: number; toNodeId: number; percent: 25 | 50 | 100 },
+  ) {
+    const runtime = this.runtime.getRuntime(payload.matchId);
+    if (!runtime || runtime.status !== 'RUNNING')
+      return { ok: false, error: { code: 'MATCH_NOT_RUNNING' } };
+    const userId = client.data.user.id as string;
+    const team: Team | null =
+      runtime.teams.A === userId
+        ? 'A'
+        : runtime.teams.B === userId
+        ? 'B'
+        : null;
+    if (!team) return { ok: false };
+    const from = runtime.nodes.get(payload.fromNodeId);
+    const to = runtime.nodes.get(payload.toNodeId);
+    if (!from || !to || from.owner !== team)
+      return { ok: false, error: { code: 'NOT_OWNER' } };
+    if (!this.runtime.isAdjacent(runtime.edges, payload.fromNodeId, payload.toNodeId))
+      return { ok: false, error: { code: 'NOT_ADJACENT' } };
+    const now = Date.now();
+    const last = runtime.lastSendByUser.get(userId) || 0;
+    if (now - last < MIN_SEND_COOLDOWN_MS)
+      return { ok: false, error: { code: 'COOLDOWN' } };
+    const qty = Math.floor((from.garrison * payload.percent) / 100);
+    if (qty < 1) return { ok: false, error: { code: 'NOT_ENOUGH_UNITS' } };
+    from.garrison -= qty;
+    runtime.lastSendByUser.set(userId, now);
+    const convoy = this.runtime.createConvoy(runtime, team, payload.fromNodeId, payload.toNodeId, qty);
+    return {
+      ok: true,
+      convoy: {
+        id: convoy.id,
+        fromNodeId: convoy.fromNodeId,
+        toNodeId: convoy.toNodeId,
+        total: convoy.total,
+        team: convoy.team,
+        departAt: convoy.departAt,
+        arriveAt: convoy.arriveAt,
+      },
+    };
+  }
+}

--- a/game/server/tsconfig.json
+++ b/game/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "strictNullChecks": false
+  }
+}


### PR DESCRIPTION
## Summary
- track live match state with tick/broadcast loops and convoy resolution
- enable match startup and troop dispatch over WebSocket with cooldown checks
- render dynamic map with garrisons and moving convoys on the Vue client
- redirect root path to login to avoid blank screen

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm run build` (server) *(fails: nest not found - dependencies missing)*
- `npm test` (client) *(fails: Missing script "test")*
- `npm run build` (client) *(fails: vite not found - dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a61d740224832c9e1055819e981bff